### PR TITLE
cleanup tests for passing acceptance run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@
 2. [Prerequisites](#windows-system-prerequisites)
 3. [Setup](#setup)
 4. [Usage](#usage)
-  * [Using PSCredential or MSFT_Credential](#using-dsc-resources-with-puppet)
-  * [Using EmbeddedInstance or CimInstance](#using-dsc-resources-with-puppet)
+  * [Specifying a DSC Resource version](#specifying-a-dsc-resource-version)
+  * [Using PSCredential or MSFT_Credential](#using-pscredential-or-msft_credential)
+  * [Using EmbeddedInstance or CimInstance](#using-embeddedinstance-or-ciminstance)
   * [Handling Reboots with DSC](#handling-reboots-with-dsc)
 5. [Reference](#reference)
   * [Types and Providers](#types-and-providers)
@@ -57,7 +58,7 @@ WindowsFeature IIS {
 ~~~puppet
 dsc {'iis':
   dsc_resource_name        => 'WindowsFeature',
-  dsc_resource_module_name => 'PSDesiredStateConfiguration',
+  dsc_resource_module => 'PSDesiredStateConfiguration',
   dsc_resource_properties  => {
     ensure => 'present',
     name   => 'Web-Server',
@@ -74,7 +75,7 @@ A contrived, but simple example follows:
 ~~~puppet
 dsc {'foo':
   dsc_resource_name        => 'xFoo',
-  dsc_resource_module_name => 'xFooBar',
+  dsc_resource_module => 'xFooBar',
   dsc_resource_properties  => {
     ensure  => 'present',
     fooinfo => {
@@ -88,6 +89,40 @@ dsc {'foo':
 }
 ~~~
 
+### Specifying a DSC Resource version
+
+When there is more than one version installed for a given DSC Resource module, you must specify the version in your declaration. You can specify the version with similar syntax to a DSC Configuration script by using a hash containing the name and version of the DSC Resource module to use.
+
+~~~puppet
+dsc {'iis_server':
+  dsc_resource_name   => 'WindowsFeature',
+  dsc_resource_module => {
+    name    => 'PSDesiredStateConfiguration',
+    version => '1.1'
+  },
+  dsc_resource_properties  => {
+    ensure => 'present',
+    name   => 'Web-Server',
+  }
+}
+~~~
+
+Specifying the path to the DSC Resource module works as well:
+
+~~~puppet
+dsc {'iis_server':
+  dsc_resource_name   => 'WindowsFeature',
+  dsc_resource_module => {
+    name    => 'C:\Windows\system32\WindowsPowershell\v1.0\Modules\PsDesiredStateConfiguration\PSDesiredStateConfiguration.psd1',
+    version => '1.1'
+  },
+  dsc_resource_properties  => {
+    ensure => 'present',
+    name   => 'Web-Server',
+  }
+}
+~~~
+
 ### Using PSCredential or MSFT_Credential
 
 Specifying credentials in DSC Resources requires using a PSCredential object. The `dsc` type will automatically create a PSCredential if the `dsc_type` has `MSFT_Credential` as a value.
@@ -95,7 +130,7 @@ Specifying credentials in DSC Resources requires using a PSCredential object. Th
 ~~~puppet
 dsc {'foouser':
   dsc_resource_name        => 'User',
-  dsc_resource_module_name => 'PSDesiredStateConfiguration',
+  dsc_resource_module => 'PSDesiredStateConfiguration',
   dsc_resource_properties  => {
     'username'    => 'jane-doe',
     'description' => 'Jane Doe user',
@@ -122,7 +157,7 @@ For example, we'll create a new IIS website using the xWebSite DSC Resource, bou
 ~~~puppet
 dsc {'NewWebsite':
   dsc_resource_name        => 'xWebsite',
-  dsc_resource_module_name => 'xWebAdministration',
+  dsc_resource_module => 'xWebAdministration',
   dsc_resource_properties  => {
     ensure       => 'Present',
     state        => 'Started',
@@ -144,7 +179,7 @@ To show using more than one value in `dsc_properties`, let's create the same sit
 ~~~puppet
 dsc {'NewWebsite':
   dsc_resource_name        => 'xWebsite',
-  dsc_resource_module_name => 'xWebAdministration',
+  dsc_resource_module => 'xWebAdministration',
   dsc_resource_properties  => {
     ensure       => 'Present',
     state        => 'Started',
@@ -201,7 +236,7 @@ The name of the declaration. This has no affect on the DSC Resource declaration 
 
 The name of the DSC Resource to use. For example, the xRemoteFile DSC Resource.
 
-#### dsc_resource_module_name
+#### dsc_resource_module
 
 The name of the DSC Resource module to use. For example, the xPSDesiredStateConfiguration DSC Resource module contains the xRemoteFile DSC Resource.
 

--- a/README_Tradeoffs.md
+++ b/README_Tradeoffs.md
@@ -24,7 +24,7 @@ You'll write a simplified declaration that looks like this:
 ```puppet
 dsc {'fruit_file':
   dsc_resource_name => 'File',
-  dsc_resource_module_name => 'PSDesiredStateConfiguration',
+  dsc_resource_module => 'PSDesiredStateConfiguration',
   dsc_resource_properties => {
     ensure          => 'present',
     content         => 'Apple, Banana, Cherry.',
@@ -109,7 +109,7 @@ If we do the same with the new `dsc_lite` module:
 ```puppet
 dsc {'fruit_file':
   dsc_resource_name => 'File',
-  dsc_resource_module_name => 'PSDesiredStateConfiguration',
+  dsc_resource_module => 'PSDesiredStateConfiguration',
   dsc_resource_properties => {
     ensure          => 'present',
     destinationpath => 1,

--- a/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
+++ b/lib/puppet/provider/base_dsc_lite/invoke_generic_dsc_resource.ps1.erb
@@ -23,7 +23,14 @@ $response = @{
 
 $invokeParams = @{
 Name       = '<%= resource.parameters[:dsc_resource_name].value %>'
-ModuleName = '<%= resource.parameters[:dsc_resource_module_name].value %>'
+ModuleName = <% if resource.parameters[:dsc_resource_module].value.is_a?(Hash) -%>
+@{
+modulename    = '<%= resource.parameters[:dsc_resource_module].value['name'] %>'
+moduleversion = '<%= resource.parameters[:dsc_resource_module].value['version'] %>'
+}
+<% else -%>
+'<%= resource.parameters[:dsc_resource_module].value %>'
+<% end -%>
 Method     = '<%= dsc_invoke_method %>'
 Property   = <% provider.dsc_property_param.each do |p| -%>
 <%= format_dsc_lite(p.value) %>

--- a/lib/puppet/type/dsc.rb
+++ b/lib/puppet/type/dsc.rb
@@ -32,14 +32,20 @@ Puppet::Type.newtype(:dsc) do
     end
   end
 
-  newparam(:dsc_resource_module_name) do
-    desc "DSC Resource Module Name"
+  newparam(:dsc_resource_module) do
+    desc "DSC Resource Module"
     isrequired
     validate do |value|
       if value.nil? or value.empty?
         raise ArgumentError, "A non-empty #{self.name.to_s} must be specified."
       end
-      fail "#{self.name.to_s} should be a String" unless value.is_a? ::String
+      fail "#{self.name.to_s} should be a Hash or String" unless value.is_a?(Hash) || value.is_a?(String)
+      if value.is_a?(Hash)
+        valid_keys = ['name','version']
+        unless (value.keys & valid_keys) == value.keys
+          fail("Must specify name and version if using ModuleSpecification")
+        end
+      end
     end
   end
 

--- a/spec/unit/puppet/type/dsc_spec.rb
+++ b/spec/unit/puppet/type/dsc_spec.rb
@@ -69,27 +69,39 @@ describe Puppet::Type.type(:dsc) do
   describe "parameter :dsc_resource_module" do
     subject { resource.parameters[:dsc_resource_module] }
     
+    it "should allow a string" do
+      expect {
+        resource[:dsc_resource_module] = 'foo'
+      }
+    end
+
+    it "should allow a hash" do
+      expect {
+        resource[:dsc_resource_module] = { 'name' => 'bar', 'version' => '1.8' }
+      }.not_to raise_error
+    end
+
+    it "should require name and version keys if hash" do
+      expect {
+        resource[:dsc_resource_module] = { 'foo' => 'bar'}
+      }.to raise_error(Puppet::Error, /Must specify name and version if using ModuleSpecification/)
+    end
+
     it "should not allow nil" do
       expect {
-        resource[:name] = nil
-      }.to raise_error(Puppet::Error, /Got nil value for name/)
+        resource[:dsc_resource_module] = nil
+      }.to raise_error(Puppet::Error, /Got nil value for dsc_resource_module/)
     end
 
     it "should not allow empty" do
       expect {
-        resource[:name] = ''
-      }.to raise_error(Puppet::ResourceError, /A non-empty name must/)
+        resource[:dsc_resource_module] = ''
+      }.to raise_error(Puppet::ResourceError, /A non-empty dsc_resource_module must/)
     end
     
     [ 'value', 'value with spaces', 'UPPER CASE', '0123456789_-', 'With.Period' ].each do |value|
       it "should accept '#{value}'" do
-        expect { resource[:name] = value }.not_to raise_error
-      end
-    end
-
-    [ '*', '()', '[]', '!@' ].each do |value|
-      it "should reject '#{value}'" do
-        expect { resource[:name] = value }.to raise_error(Puppet::ResourceError, /is not a valid name/)
+        expect { resource[:dsc_resource_module] = value }.not_to raise_error
       end
     end
   end

--- a/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/multi_failing_dsc_resources.rb
@@ -13,7 +13,7 @@ throw_message_2 = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { 'throw_1':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => 'foo',
@@ -23,7 +23,7 @@ dsc { 'throw_1':
 
 dsc { 'throw_2':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => 'bar',

--- a/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
+++ b/tests/acceptance/tests/basic_dsc_resources/some_failing_dsc_resources.rb
@@ -12,7 +12,7 @@ throw_message = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { 'good_resource':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => 'foo',
@@ -21,7 +21,7 @@ dsc { 'good_resource':
 
 dsc { 'throw_resource':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => 'bar',

--- a/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
+++ b/tests/acceptance/tests/basic_functionality/alternate_path_separator.rb
@@ -21,7 +21,7 @@ file { 'C:/#{ test_dir_path }' :
 ->
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{original_contents}',
@@ -40,7 +40,7 @@ file { 'C:/#{ test_dir_path }' :
 ->
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{updated_contents}',

--- a/tests/acceptance/tests/basic_functionality/negative/dsc_on_linux.rb
+++ b/tests/acceptance/tests/basic_functionality/negative/dsc_on_linux.rb
@@ -13,7 +13,7 @@ test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_debug_dsc_manifest.rb
@@ -19,7 +19,7 @@ file { 'C:/#{ test_dir_path }' :
 ->
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_dsc_manifest.rb
@@ -19,7 +19,7 @@ file { 'C:/#{ test_dir_path }' :
 ->
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
+++ b/tests/acceptance/tests/basic_functionality/puppet_apply_noop_dsc_manifest.rb
@@ -18,7 +18,7 @@ file { 'C:/#{ test_dir_path }' :
 ->
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{SecureRandom.uuid}',

--- a/tests/acceptance/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
+++ b/tests/acceptance/tests/dsc_type/custom_resource_from_system_PSModulePath.rb
@@ -14,7 +14,7 @@ dsc_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'PuppetFakeResource',
   # NOTE: relies on finding resource in system part of $ENV:PSModulePath
-  dsc_resource_module_name => 'PuppetFakeResource',
+  dsc_resource_module => 'PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/dsc_type/custom_resource_path.rb
+++ b/tests/acceptance/tests/dsc_type/custom_resource_path.rb
@@ -12,7 +12,7 @@ dsc_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
   # NOTE: install_fake_reboot_resource installs on master, which pluginsyncs here
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
@@ -55,7 +55,7 @@ end
 dsc_remove_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'absent',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
+++ b/tests/acceptance/tests/dsc_type/multiple_dsc_resources_in_PSModulePath.rb
@@ -63,7 +63,7 @@ dsc_ambiguous_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'PuppetFakeResource',
   # NOTE: relies on finding resource in system parts of $ENV:PSModulePath
-  dsc_resource_module_name => 'PuppetFakeResource',
+  dsc_resource_module => 'PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
@@ -94,8 +94,10 @@ dsc_versioned_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'PuppetFakeResource',
   # NOTE: relies on finding resource in system parts of $ENV:PSModulePath
-  dsc_resource_module_name => 'PuppetFakeResource',
-  dsc_resource_module_version => '2.0',
+  dsc_resource_module => {
+    name    => 'PuppetFakeResource',
+    version => '2.0',
+  }
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
@@ -108,20 +110,12 @@ MANIFEST
 confine_block(:to, :platform => 'windows') do
   agents.each do |agent|
     step 'Run Puppet Apply'
-    # this scenario expectedly fails as DSC doesn't know which version to use
     on(agent, puppet('apply'), :stdin => dsc_versioned_manifest, :acceptable_exit_codes => [1]) do |result|
-      expect_failure('Cannot yet specify module version until MODULES-5845 implemented') do
-        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
-      end
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     end
 
     step 'Verify Results'
-    # PuppetFakeResource always overwrites file at this path
-    # PuppetFakeResourc2 2.0 appends "v2" to the written file before "ImportantStuff"
-    on(agent, "cat /cygdrive/c/#{fake_name}", :acceptable_exit_codes => [1]) do |result|
-      expect_failure('Cannot yet execute PuppetFakeResource 2.0 until MODULES-5845 implemented') do
-        assert_match(/^v2#{test_file_contents}/, result.stdout, 'PuppetFakeResource File contents incorrect!')
-      end
-    end
+    # if this file exists, 'absent' didn't work
+    on(agent, "test -f /cygdrive/c/#{fake_name}", :acceptable_exit_codes => [1])
   end
 end

--- a/tests/acceptance/tests/dsc_type/psdesiredstateconfiguration.rb
+++ b/tests/acceptance/tests/dsc_type/psdesiredstateconfiguration.rb
@@ -9,7 +9,7 @@ test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'file',
-  dsc_resource_module_name => 'PSDesiredStateConfiguration',
+  dsc_resource_module => 'PSDesiredStateConfiguration',
   dsc_resource_properties => {
     ensure          => 'present',
     contents  => '#{test_file_contents}',
@@ -52,7 +52,7 @@ end
 dsc_remove_manifest = <<-MANIFEST
 dsc {'#{fake_name}':
   dsc_resource_name => 'file',
-  dsc_resource_module_name => 'PSDesiredStateConfiguration',
+  dsc_resource_module => 'PSDesiredStateConfiguration',
   dsc_resource_properties => {
     ensure          => 'absent',
     contents  => '#{test_file_contents}',

--- a/tests/acceptance/tests/ensure_behavior/ensure_absent.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_absent.rb
@@ -11,7 +11,7 @@ test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
@@ -51,7 +51,7 @@ end
 dsc_remove_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'absent',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_and_dsc_ensure_present.rb
@@ -11,7 +11,7 @@ test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',

--- a/tests/acceptance/tests/ensure_behavior/ensure_present.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_present.rb
@@ -11,7 +11,7 @@ test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     importantstuff  => '#{test_file_contents}',
     destinationpath => 'C:\\#{fake_name}',

--- a/tests/acceptance/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
+++ b/tests/acceptance/tests/ensure_behavior/ensure_present_and_dsc_ensure_absent.rb
@@ -11,7 +11,7 @@ test_file_contents = SecureRandom.uuid
 dsc_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'present',
     importantstuff  => '#{test_file_contents}',
@@ -49,7 +49,7 @@ end
 dsc_remove_manifest = <<-MANIFEST
 dsc { '#{fake_name}':
   dsc_resource_name => 'puppetfakeresource',
-  dsc_resource_module_name => '#{installed_path}/PuppetFakeResource',
+  dsc_resource_module => '#{installed_path}/PuppetFakeResource',
   dsc_resource_properties => {
     ensure          => 'absent',
     importantstuff  => '#{test_file_contents}',


### PR DESCRIPTION
Acceptance changes necessary for suite to pass.


 - Vetted with:

 BEAKER_PUPPET_AGENT_VERSION=1.10.9 GEM_SOURCE=http://rubygems.delivery.puppetlabs.net bundle exec beaker --preserve-hosts onfail --config tests/configs/windows-2012r2-64a --debug --tests tests/acceptance/tests --keyfile ~/.ssh/id_rsa-acceptance --pre-suite tests/acceptance/pre-suite --load-path tests/lib --type aio